### PR TITLE
Support request and success mime types

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -12,6 +12,7 @@ export const DEFAULT_CONFIG = {
       requestBody: 'Encodable',
       response: 'Decodable',
     },
+    mime: {},
   },
 }
 

--- a/src/errors/UnsupportedKeywordError.js
+++ b/src/errors/UnsupportedKeywordError.js
@@ -1,0 +1,3 @@
+
+export default class UnsupportedKeywordError extends Error {
+}

--- a/src/graph/RequestBody.js
+++ b/src/graph/RequestBody.js
@@ -5,7 +5,7 @@ import Model from "./Node.js";
 
 export default class RequestBody extends Model {
   /**
-   * @param {object} schema 
+   * @param {object|string} schema 
    */
   constructor(schema) {
     super('RequestBody', schema)

--- a/src/parser/Parser.js
+++ b/src/parser/Parser.js
@@ -464,10 +464,19 @@ export default class Parser {
       this.next()
       while (this.currentToken.not('}')) {
         switch (this.currentToken.token) {
-          case 'success':
           case 'request':
+          case 'success':
             const name = this.currentToken.token
             this.next()
+            if (this.currentToken.is('mime')) {
+              this.next()
+              this.assert(':')
+              this.next()
+              const mimeType = this.currentToken.token
+              endpointSchema[name] = `mime:${mimeType}`
+              this.next()
+              break
+            }
             this.assert('{')
             this.push(name)
             this.log(`[Schema] .${name}`)

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -95,6 +95,20 @@ entity Note {
   t.is(result[0].summary, 'Note Summary')
 })
 
+test('parse endpoint request with mime-type', t => {
+  const schema = `
+entity UserImage {
+  endpoint POST /user_images {
+    request mime:image/jpeg
+  }
+}`
+  const parser = new Parser('test.soil', schema)
+  const result = parser.parse()
+
+  t.is(result.length, 1)
+  t.is(result[0].endpoints['/user_images'].post.request, 'mime:image/jpeg')
+})
+
 // tokenize
 
 test('tokenize basic entity', t => {

--- a/test/RequestBody.test.js
+++ b/test/RequestBody.test.js
@@ -1,0 +1,30 @@
+import test from 'ava'
+import RequestBody from '../src/graph/RequestBody.js'
+import UnsupportedKeywordError from '../src/errors/UnsupportedKeywordError.js'
+
+import { DEFAULT_CONFIG } from '../src/const.js'
+import contextUtilities from '../src/context.js'
+
+const context = {
+  config: DEFAULT_CONFIG,
+  ...contextUtilities,
+}
+
+import '../src/swift.js'
+
+test('[Swift] with supported mime-type', t => {
+  const request = new RequestBody('mime:application/json')
+  t.is(request.renderSwiftStruct(context), 'public typealias RequestBody = Data')
+})
+
+test('[Swift] with configured mime-type', t => {
+  const request = new RequestBody('mime:video/mp2t')
+  t.is(request.renderSwiftStruct({ ...context, config: { ...context.config, swift: { ...context.config.swift, mime: { 'video/mp2t': 'Video' } } } }), 'public typealias RequestBody = Video')
+})
+
+test('[Swift] with unsupported mime-type', t => {
+  const request = new RequestBody('mime:audio/webm')
+  t.throws(() => {
+    request.renderSwiftStruct(context)
+  }, { instanceOf: UnsupportedKeywordError })
+})

--- a/test/Response.test.js
+++ b/test/Response.test.js
@@ -1,0 +1,30 @@
+import test from 'ava'
+import Response from '../src/graph/Response.js'
+import UnsupportedKeywordError from '../src/errors/UnsupportedKeywordError.js'
+
+import { DEFAULT_CONFIG } from '../src/const.js'
+import contextUtilities from '../src/context.js'
+
+const context = {
+  config: DEFAULT_CONFIG,
+  ...contextUtilities,
+}
+
+import '../src/swift.js'
+
+test('[Swift] with supported mime-type', t => {
+  const request = new Response('mime:application/json')
+  t.is(request.renderSwiftStruct(context), 'public typealias Response = Data')
+})
+
+test('[Swift] with configured mime-type', t => {
+  const request = new Response('mime:video/mp2t')
+  t.is(request.renderSwiftStruct({ ...context, config: { ...context.config, swift: { ...context.config.swift, mime: { 'video/mp2t': 'Video' } } } }), 'public typealias Response = Video')
+})
+
+test('[Swift] with unsupported mime-type', t => {
+  const request = new Response('mime:audio/webm')
+  t.throws(() => {
+    request.renderSwiftStruct(context)
+  }, { instanceOf: UnsupportedKeywordError })
+})


### PR DESCRIPTION
refs #18 

- supports request and response mime-type
- only `application/json`, `text/{any}`, `image/{any}`