### PR TITLE
Added: Shared scenario

### DIFF
--- a/src/graph/Root.js
+++ b/src/graph/Root.js
@@ -37,6 +37,15 @@ export default class Root extends Node {
   }
 
   /**
+   * 
+   * @param {string} name
+   * @returns {Scenario|undefined}
+   */
+  findScenario (name) {
+    return this.scenarios.find(scenario => scenario.name == name)
+  }
+
+  /**
    * @param {string} referenceBody 
    * @param {boolean} allowGlobalFinding 
    * @returns {Node|undefined}

--- a/src/graph/Scenario.js
+++ b/src/graph/Scenario.js
@@ -29,4 +29,11 @@ export default class Scenario extends Node {
       .filter(step => step instanceof Node)
       .forEach(step => step.moveToParent(this))
   }
+
+  /**
+   * @type {boolean}
+   */
+  get isShared () {
+    return this.schema.annotation == 'shared'
+  }
 }

--- a/src/graph/Schema.js
+++ b/src/graph/Schema.js
@@ -15,6 +15,15 @@ import '../kotlin.js'
 import '../swift.js'
 
 export default class Schema {
+  /**
+   * @type {Root}
+   */
+  root
+
+  /**
+   * 
+   * @param {any} config 
+   */
   constructor(config) {
     Object.defineProperty(this, 'config', { value: config })
   }

--- a/src/parser/Parser.js
+++ b/src/parser/Parser.js
@@ -37,11 +37,19 @@ const KEYWORD_PARAMETER   = 'parameter'
 const KEYWORD_QUERY       = 'query'
 const KEYWORD_SCHEMA      = 'schema'
 const KEYWORD_RECEIVER    = 'receiver'
+
+// Field annotation
 const KEYWORD_MUTABLE     = 'mutable'
 const KEYWORD_REFERENCE   = 'reference'
 const KEYWORD_IDENTIFIER  = 'identifier'
 const KEYWORD_WRITER      = 'writer'
+
+// Query annotation
 const KEYWORD_REQUIRED    = 'required'
+
+// Scenario annotation
+const KEYWORD_SHARED      = 'shared'
+
 const KEYWORD_ID          = 'id'
 const KEYWORD_DEFAULT     = 'default'
 const KEYWORD_EXAMPLE     = 'example'
@@ -358,6 +366,12 @@ export default class Parser {
         case KEYWORD_SCENARIO:
           this.scenarios.push(this.parseScenario())
           break
+        // scenario annotation
+        case KEYWORD_SHARED:
+          this.currentToken.kind = `keyword.other.shared`
+          this.next()
+          this.assert(KEYWORD_SCENARIO)
+          break
         default:
           throw new SyntaxError(this.currentToken)
       }
@@ -504,6 +518,9 @@ export default class Parser {
   parseScenario () {
     this.assert(KEYWORD_SCENARIO)
     this.currentToken.asDirective(KEYWORD_SCENARIO)
+
+    const annotation = this.tokens[this.offset - 1]
+
     this.next()
     this.assertSematicEntity(KEYWORD_ENTITY, ENTITY_NAME_PATTERN)
 
@@ -519,6 +536,11 @@ export default class Parser {
       name,
       uri: this.currentToken.uri,
       steps: [],
+    }
+
+    if (annotation && annotation.is(/^(shared)$/)) {
+      scenarioSchema.annotation = annotation.token
+      annotation.kind = `keyword.annotation.${annotation.token}`
     }
 
     this.log(`[Scenario] ${name}`)

--- a/src/soil.js
+++ b/src/soil.js
@@ -68,10 +68,11 @@ const commands = {
       schema.parse(await loader.load())
       schema.debug()
       for (const scenario of schema.scenarios) {
+        if (scenario.isShared) continue
         if (soil.options.verbose) {
           console.log(util.inspect(scenario.steps, { depth: null, colors: true }))
         }
-        const runner = new Runner()
+        const runner = new Runner(config, schema.root)
         try {
           runner.log('scenario file:', scenario.uri)
           await runner.runScenario(scenario)

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,8 @@ export const configTemplate = new Config()
    * @see https://github.com/niaeashes/soil/issues/32
    */
   .string('booleanQuery', 'set-only-true')
+
+  .anyStringTable('headers')
 )
 
 .addDirective('swift', swift => swift


### PR DESCRIPTION
- Add `shared` annotation for scenario directive: shared scenario is not running when replay scenario.
- Add `@use` command: it call the another scenario under the nested context.
- Add `api.headers` config.

example:

```soil
shared scenario Signup {
  POST /users {
    username = user-$rand
    password = password
  }
}
scenario Get Profile {
  @use(Signup)
  GET /users/me
}
```